### PR TITLE
[CPAN-RT #82887] Incorrect handling of taint mode and search paths

### DIFF
--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -342,7 +342,7 @@ sub _is_in_taint_mode {
     open(my $f, "<", $file) or die "could not open $file";
     my $shebang = <$f>;
     my $taint = "";
-    if ($shebang =~ /^#!\s*[\/\w]+\s+-\w*([tT])/)/) {
+    if ($shebang =~ /^#!\s*[\/\w]+\s+-\w*([tT])/) {
         $taint = $1;
     }
     return $taint;


### PR DESCRIPTION
These patches fixes the problems signaled in CPAN-RT #82887:
- correctly handle library search paths
- fix regexp to detect taint mode option on a shebang

» https://rt.cpan.org/Ticket/Display.html?id=82887
