### PR TITLE
Replaced import() with Exporter usage.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,6 +15,8 @@ my $build = Module::Build->new (
        'perl'               => '5.6.2',
        'UNIVERSAL::require' => 0,
        'version'            => 0,
+       'parent'             => '0.225',
+       'Exporter'           => '5.68',
     },
     recommends => {
         'Devel::CheckOS' => 0,

--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Test-Compile
 
+v1.2.3    UNRELEASED              (Łukasz Hejnak <lehack@lehack.pl>)
+    - Replaced import() with Exporter usage.
+    - Added all_files_ok to the procedural mode.
+    - Added .git to list of directories ignored when looking for pm/pl files.
+    - Added an else clause for pl_file_compiles so that it catches file not found errors.
+
 v1.2.2    UNRELEASED              (Evan Giles <egiles@cpan.org>)
     - Remove the 'use 5.6.2' statements, they cause warnings.
     - Fix some spelling errors

--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ t/100-internal-mess-with-lib.t
 t/100-internal-pl-file-compiles.t
 t/100-internal-pm-file-compiles.t
 t/100-internal-verbose.t
+t/200-import_check.t
 t/200-pl-file-ok.t
 t/200-pl-file-ok-vms.t
 t/200-taint.t

--- a/README
+++ b/README
@@ -8,6 +8,8 @@ DEPENDENCIES
     Requires perl v5.6.2, plus
     * UNIVERSAL::require
     * version
+    * parent
+    * Exporter
 
 INSTALLATION
     Standard process for building & installing modules:

--- a/lib/Test/Compile.pm
+++ b/lib/Test/Compile.pm
@@ -4,6 +4,7 @@ use warnings;
 use strict;
 
 use version; our $VERSION = qv("v1.2.2");
+use parent 'Exporter';
 use UNIVERSAL::require;
 use Test::Compile::Internal;
 
@@ -22,7 +23,7 @@ Test::Compile - Check whether Perl files compile correctly.
     $test->done_testing();
 
     # The procedural way
-    use Test::Compile;
+    use Test::Compile qw( all_pm_files_ok );
     all_pm_files_ok();
 
 =head1 DESCRIPTION
@@ -47,21 +48,18 @@ in a module distribution:
 
 =cut
 
-sub import {
-    my $self   = shift;
-    my $caller = caller;
-    for my $func (
-        qw(
-        pm_file_ok pl_file_ok all_pm_files all_pl_files all_pm_files_ok
-        all_pl_files_ok
-        )
-      ) {
-        no strict 'refs';
-        *{ $caller . "::" . $func } = \&$func;
-    }
-    $Test->exported_to($caller);
-    $Test->plan(@_);
-}
+our @EXPORT_OK = qw(
+    pm_file_ok
+    pl_file_ok
+
+    all_files_ok
+    all_pm_files_ok
+    all_pl_files_ok
+
+    all_pm_files
+    all_pl_files
+);
+our %EXPORT_TAGS = ('all' => [ @EXPORT_OK ]);
 
 =head1 METHODS
 
@@ -201,7 +199,9 @@ in a module distribution:
     eval "use Test::Compile";
     Test::More->builder->BAIL_OUT(
         "Test::Compile required for testing compilation") if $@;
-    all_pm_files_ok();
+    my $test = Test::Compile->new();
+    $test->all_pm_files_ok();
+    $test->done_testing();
 
 =cut
 
@@ -239,7 +239,9 @@ in a module distribution:
     eval "use Test::Compile";
     plan skip_all => "Test::Compile required for testing compilation"
       if $@;
-    all_pl_files_ok();
+    my $test = Test::Compile->new();
+    $test->all_pl_files_ok();
+    $test->done_testing();
 
 =cut
 
@@ -342,11 +344,24 @@ Skips any files in C<CVS> or C<.svn> directories.
 The order of the files returned is machine-dependent. If you want them
 sorted, you'll have to sort them yourself.
 
-=back
 =cut
 
 sub all_pl_files {
     return $Test->all_pl_files(@_);
+}
+
+=item C<all_files_ok(@dirs)>
+
+Checks all the perl files it can find for compilation errors.
+
+If C<@dirs> is defined then it is taken as an array of directories to
+be searched for perl files, otherwise it searches some default locations
+- see L</all_pm_files()> and L</all_pl_files()>.
+
+=back
+=cut
+sub all_files_ok {
+    return $Test->all_files_ok(@_);
 }
 
 sub _verbose {

--- a/lib/Test/Compile.pm
+++ b/lib/Test/Compile.pm
@@ -3,7 +3,7 @@ package Test::Compile;
 use warnings;
 use strict;
 
-use version; our $VERSION = qv("v1.2.2");
+use version; our $VERSION = qv("v1.2.3");
 use parent 'Exporter';
 use UNIVERSAL::require;
 use Test::Compile::Internal;
@@ -59,7 +59,7 @@ our @EXPORT_OK = qw(
     all_pm_files
     all_pl_files
 );
-our %EXPORT_TAGS = ('all' => [ @EXPORT_OK ]);
+our %EXPORT_TAGS = ('all' => \@EXPORT_OK);
 
 =head1 METHODS
 

--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -171,6 +171,10 @@ sub pl_file_compiles {
                 system($^X, (map { "-I$_" } @inc), "-c$taint", $file);
                 return ($? ? 0 : 1);
             }
+            else {
+                $self->{test}->diag("$file could not be found") if $self->verbose();
+                return 0;
+            }
         }
     );
 }
@@ -328,7 +332,7 @@ sub _find_files {
             my @newfiles = readdir DH;
             closedir DH;
             @newfiles = File::Spec->no_upwards(@newfiles);
-            @newfiles = grep { $_ ne "CVS" && $_ ne ".svn" } @newfiles;
+            @newfiles = grep { $_ ne "CVS" && $_ ne ".svn" && $_ ne ".git" } @newfiles;
             for my $newfile (@newfiles) {
                 my $filename = File::Spec->catfile($file, $newfile);
                 if (-f $filename) {

--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -3,7 +3,7 @@ package Test::Compile::Internal;
 use warnings;
 use strict;
 
-use version; our $VERSION = qv("v1.2.2");
+use version; our $VERSION = qv("v1.2.3");
 use File::Spec;
 use UNIVERSAL::require;
 use Test::Builder;

--- a/t/200-import_check.t
+++ b/t/200-import_check.t
@@ -1,0 +1,39 @@
+#!perl -w
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Compile;
+Test::Compile::_verbose(0);
+
+my @METHODS = qw(
+    pm_file_ok
+    pl_file_ok
+
+    all_files_ok
+    all_pm_files_ok
+    all_pl_files_ok
+
+    all_pm_files
+    all_pl_files
+);
+
+plan tests => 2 * @METHODS + 2;
+
+# try to use the methods, despite not exporting them
+for my $m (@METHODS) {
+    is(__PACKAGE__->can($m), undef, "$m not auto-imported");
+} 
+
+# now run (inherited) import by hand with specified method
+Test::Compile->import('pl_file_ok');
+
+lives_ok {
+    pl_file_ok('t/scripts/subdir/success.pl', 'success.pl compiles');
+} 'pl_file_ok imported correctly';
+
+# finally use the "all" tag to import all methods and check if it worked
+Test::Compile->import(':all');
+for my $m (@METHODS) {
+    is(__PACKAGE__->can($m), \&{ $m }, "$m imported via 'all' tag");
+} 

--- a/t/200-import_check.t
+++ b/t/200-import_check.t
@@ -18,7 +18,7 @@ my @METHODS = qw(
     all_pl_files
 );
 
-plan tests => 2 * @METHODS + 2;
+plan tests => @METHODS + 3;
 
 # try to use the methods, despite not exporting them
 for my $m (@METHODS) {
@@ -33,7 +33,6 @@ lives_ok {
 } 'pl_file_ok imported correctly';
 
 # finally use the "all" tag to import all methods and check if it worked
+diag 'Use :all import tag and check if methods got imported correctly';
 Test::Compile->import(':all');
-for my $m (@METHODS) {
-    is(__PACKAGE__->can($m), \&{ $m }, "$m imported via 'all' tag");
-} 
+can_ok(__PACKAGE__, @METHODS);

--- a/t/200-pl-file-ok-vms.t
+++ b/t/200-pl-file-ok-vms.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 1;
-use Test::Compile;
+use Test::Compile qw( pl_file_ok );
 
 # cheap emulation
 $^O = 'VMS';

--- a/t/200-pl-file-ok.t
+++ b/t/200-pl-file-ok.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 1;
-use Test::Compile qw(pl_file_ok);
+use Test::Compile qw( pl_file_ok );
 
 Test::Compile::_verbose(0);
 pl_file_ok('t/scripts/subdir/success.pl', 'success.pl compiles');

--- a/t/200-pl-file-ok.t
+++ b/t/200-pl-file-ok.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 1;
-use Test::Compile;
+use Test::Compile qw(pl_file_ok);
 
 Test::Compile::_verbose(0);
 pl_file_ok('t/scripts/subdir/success.pl', 'success.pl compiles');

--- a/t/200-taint.t
+++ b/t/200-taint.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 1;
-use Test::Compile;
+use Test::Compile qw( pl_file_ok );
 
 Test::Compile::_verbose(0);
 pl_file_ok('t/scripts/taint.pl', 'taint.pl compiles');

--- a/t/scripts/lib.pl
+++ b/t/scripts/lib.pl
@@ -3,6 +3,7 @@
 BEGIN {
     require strict;
     require warnings;
+    require parent;
     require Test::Builder;
     require File::Spec;
     require UNIVERSAL::require;


### PR DESCRIPTION
Now the user has to make a conscious choice about which methods to import when using Test::Compile (though he can still choose: use Test::Compile qw(:all)).
Updated all usage examples with the (recommended) OO usage.
Added all_files_ok to the procedural mode.
Added .git to list of directories ignored when looking for pm/pl files.
Added an else clause for pl_file_compiles().
