### PR TITLE
fix all_pl_files_ok(): use pl_file_compiles()

### DIFF
--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -99,7 +99,7 @@ sub all_pl_files_ok {
     my $test = $self->{test};
 
     for my $file ( $self->all_pl_files(@dirs) ) {
-        my $ok = $self->pm_file_compiles($file);
+        my $ok = $self->pl_file_compiles($file);
         $test->ok($ok, "$file compiles");
     }
 }


### PR DESCRIPTION
Fixes failure on script files that do not have a ".pl" extension:
all_pl_files_ok() was calling pm_file_compiles, which would add a ".pm"
extension to the file, and then fail to find the file.