### PR TITLE
Make it work on "perl in space"

### DIFF
--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -372,7 +372,7 @@ sub _perl_file_compiles {
 
     my @inc = ('blib/lib', @INC);
     my $taint = $self->_is_in_taint_mode($file);
-    my $command = join(" ", ($^X, (map { "-I$_" } @inc), "-c$taint", $file));
+    my $command = join(" ", (qq{"$^X"}, (map { qq{"-I$_"} } @inc), "-c$taint", $file));
     if ( $self->verbose() ) {
         $self->{test}->diag("Executing: " . $command);
     }

--- a/t/200-pl-file-ok-vms.t
+++ b/t/200-pl-file-ok-vms.t
@@ -1,8 +1,12 @@
 #!perl -w
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More;
 use Test::Compile qw( pl_file_ok );
+
+plan skip_all => 'No Devel::CheckOS, skipping'
+    unless Devel::CheckOS->require;
+plan tests => 1;
 
 # cheap emulation
 $^O = 'VMS';


### PR DESCRIPTION
If perl is installed in a directory with a space in it, the library does not work. This makes it do so.

Also, `t/200-pl-file-ok-vms.t` fails on Strawberry Perl if `Devel::CheckOS` is not installed. This also fixes that.