### PR TITLE
Make all_files_ok() always test the same set of files

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@ Revision history for Perl extension Test-Compile
 
 v2.4.1    2020-07-06
     - (mohawk2) Fix if perl is installed in a dir with a space in it's path
-    - (mohawk2) Fix for Strwberry perl without Devel::CheckOS
+    - (mohawk2) Fix for Strawberry perl without Devel::CheckOS
 
 v2.4.0    2020-03-29
     - RT-132153: Be more verbose when in verbose mode

--- a/lib/Test/Compile/Internal.pm
+++ b/lib/Test/Compile/Internal.pm
@@ -60,7 +60,10 @@ for details.
 sub all_files_ok {
     my ($self, @dirs) = @_;
 
-    if ( $self->all_pm_files_ok(@dirs) && $self->all_pl_files_ok(@dirs) ) {
+    my $pm_ok = $self->all_pm_files_ok(@dirs);
+    my $pl_ok = $self->all_pl_files_ok(@dirs);
+
+    if ( $pm_ok && $pl_ok ) {
         return 1;
     }
 }


### PR DESCRIPTION
PL files were skipped if any PM file failed.